### PR TITLE
매매 앙상블 로직 변경

### DIFF
--- a/strategy/news_sentiment.py
+++ b/strategy/news_sentiment.py
@@ -13,6 +13,9 @@ class NewsSentiment:
         news_items = [entry['title'] for entry in feed['entries'][:max_items]]
         return news_items
 
+    def get_scores(self):
+        return [TextBlob(news).sentiment.polarity for news in self.get_news()]
+
     def analyze_sentiment(self):
         scores = [TextBlob(news).sentiment.polarity for news in self.get_news()]
         return sum(scores) / len(scores)


### PR DESCRIPTION
- 변동성 돌파 전략 k값 수정 : 0.5 → 0.3
- 뉴스 감정 분석 로직 수정 : 긍정 비율 >= 0.6 && 평균 점수 > -0.05